### PR TITLE
Migrate to dart NNBD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- Enable NNBD, bumping minimum sdk version to 2.12.0
+
 ## 0.1.0+2
 
 - Code formatting (using dartfmt)

--- a/lib/delta_e.dart
+++ b/lib/delta_e.dart
@@ -224,7 +224,7 @@ class LabColor {
     List<num> rgb = [red, green, blue].map((int channel) {
       double value = channel / 255;
       if (value > 0.04045) {
-        value = pow(((value + 0.055) / 1.055), 2.4);
+        value = pow(((value + 0.055) / 1.055), 2.4).toDouble();
       } else {
         value /= 12.92;
       }
@@ -244,9 +244,9 @@ class LabColor {
     }).toList();
 
     return LabColor(
-      (116 * xyz[1]) - 16,
-      500 * (xyz[0] - xyz[1]),
-      200 * (xyz[1] - xyz[2]),
+      (116.0 * xyz[1]) - 16,
+      500.0 * (xyz[0] - xyz[1]),
+      200.0 * (xyz[1] - xyz[2]),
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,10 +3,10 @@ description: CIE color difference algorithms in Dart. This contains the dE76, dE
 author: RagePeanut <ragepeanut1@gmail.com>
 homepage: https://github.com/RagePeanut/DeltaE
 
-version: 0.1.0+2
+version: 0.2.0
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
 dev_dependencies:


### PR DESCRIPTION
The tests passed successfully. I had to add the `.toDouble()` and the `.0`s because the values were of type `num` and being implicitly downcasted to `double`, which was being hinted at by my ide. An good catch tho.